### PR TITLE
fix: add forceUnlock param

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,8 @@ class TrezorKeyring extends EventEmitter {
     return Boolean(this.hdk && this.hdk.publicKey);
   }
 
-  unlock() {
-    if (this.isUnlocked()) {
+  unlock(forceUnlock = false) {
+    if (this.isUnlocked() && !forceUnlock) {
       return Promise.resolve('already unlocked');
     }
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

This PR allows force triggering the `unlock` method of this keyring which obtains the public key of the selected Trezor device, to fix an issue that always displayed the accounts of the first connected device when attempting to connect multiple.